### PR TITLE
Issue #678 Revoke then Destroy in TestProxyKmipClientIntegration

### DIFF
--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -39,6 +39,7 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
 
         uuids = self.client.locate()
         for uuid in uuids:
+            # Try to revoke the uuid. If the uuid is not for a key then just destroy without revoking.
             try:
                 self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uuid)
             except exceptions.KmipOperationFailure:
@@ -60,6 +61,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             key.cryptographic_algorithm,
             enums.CryptographicAlgorithm.AES)
         self.assertEqual(key.cryptographic_length, 256)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
 
     def test_create_get_wrapped_destroy(self):
         """
@@ -97,6 +104,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         )
 
         self.assertNotEqual(unwrapped_key.value, wrapped_key.value)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
+        self.client.destroy(key_id)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, key_id)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, key_id)
 
     def test_symmetric_key_register_get_destroy(self):
         """
@@ -120,6 +133,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIsInstance(result, objects.SymmetricKey)
         self.assertEqual(
             result, key, "expected {0}\nobserved {1}".format(result, key))
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
 
     def test_register_wrapped_get_destroy(self):
         """
@@ -165,6 +184,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             enums.EncodingOption.NO_ENCODING,
             key_wrapping_data.get('encoding_option')
         )
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
+        self.client.destroy(key_id)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, key_id)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy,key_id)
     
     def test_register_app_specific_get(self):
         """
@@ -251,6 +276,18 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             private_key.cryptographic_algorithm,
             enums.CryptographicAlgorithm.RSA)
         self.assertEqual(private_key.cryptographic_length, 2048)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, public_uid)
+        self.client.destroy(public_uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, public_uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, public_uid)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, private_uid)
+        self.client.destroy(private_uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, private_uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, private_uid)
 
     def test_public_key_register_get_destroy(self):
         """
@@ -289,6 +326,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIsInstance(result, objects.PublicKey)
         self.assertEqual(
             result, key, "expected {0}\nobserved {1}".format(result, key))
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
 
     def test_private_key_register_get_destroy(self):
         """
@@ -389,6 +432,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIsInstance(result, objects.PrivateKey)
         self.assertEqual(
             result, key, "expected {0}\nobserved {1}".format(result, key))
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
 
     def test_x509_certificate_register_get_destroy(self):
         """
@@ -461,6 +510,13 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             result, cert, "expected {0}\nobserved {1}".format(
                 result, cert))
 
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
+
     def test_secret_data_register_get_destroy(self):
         """
         Test that the ProxyKmipClient can register, retrieve, and destroy a
@@ -480,6 +536,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertEqual(
             result, secret, "expected {0}\nobserved {1}".format(
                 result, secret))
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
                 
     def test_secret_data_register_get_destroy_app_specific(self):
         """
@@ -546,11 +608,16 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             'Testing4',
             attribute2.attribute_value.application_data
         )
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
 
-    def test_opaque_object_register_get_destroy(self):
+    def test_opaque_object_register_get(self):
         """
-        Test that the ProxyKmipClient can register, retrieve, and destroy an
-        opaque object.
+        Test that the ProxyKmipClient can register and retrieve an opaque object.
         """
         # Object encoding obtained from Section 3.1.5 of the KMIP 1.1 test
         # documentation.
@@ -564,6 +631,7 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIsInstance(result, objects.OpaqueObject)
         self.assertEqual(
             result, obj, "expected {0}\nobserved {1}".format(result, obj))
+        # An OpaqueData object has no state and cannot be revoked.
 
     def test_derive_key_using_pbkdf2(self):
         """
@@ -906,6 +974,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         )
 
         self.assertEqual(result, enums.ValidityIndicator.VALID)
+
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, public_key_id)
+        self.client.destroy(public_key_id)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, private_key_id)
+        self.client.destroy(private_key_id)
+
 
     def test_certificate_register_locate_destroy(self):
         """
@@ -1330,6 +1404,10 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             ]
         )
         self.assertEqual(0, len(result))
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, a_id)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, b_id)
+        self.client.destroy(a_id)
+        self.client.destroy(b_id)
 
     def test_split_key_register_get_destroy(self):
         """
@@ -1377,6 +1455,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertEqual(2, result.split_key_threshold)
         self.assertEqual(enums.SplitKeyMethod.XOR, result.split_key_method)
         self.assertIsNone(result.prime_field_size)
+        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
+        self.client.destroy(uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.get, uid)
+        self.assertRaises(
+            exceptions.KmipOperationFailure, self.client.destroy, uid)
 
     def test_modify_delete_attribute(self):
         """

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -39,8 +39,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
 
         uuids = self.client.locate()
         for uuid in uuids:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uuid)
-            self.client.destroy(uid=uuid)
+            try:
+                self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uuid)
+            except exceptions.KmipOperationFailure:
+                pass
+            finally:
+                self.client.destroy(uid=uuid)
 
     def test_symmetric_key_create_get_destroy(self):
         """
@@ -50,20 +54,12 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.create(enums.CryptographicAlgorithm.AES, 256)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            key = self.client.get(uid)
-            self.assertIsInstance(key, objects.SymmetricKey)
-            self.assertEqual(
-                key.cryptographic_algorithm,
-                enums.CryptographicAlgorithm.AES)
-            self.assertEqual(key.cryptographic_length, 256)
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        key = self.client.get(uid)
+        self.assertIsInstance(key, objects.SymmetricKey)
+        self.assertEqual(
+            key.cryptographic_algorithm,
+            enums.CryptographicAlgorithm.AES)
+        self.assertEqual(key.cryptographic_length, 256)
 
     def test_create_get_wrapped_destroy(self):
         """
@@ -102,11 +98,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
 
         self.assertNotEqual(unwrapped_key.value, wrapped_key.value)
 
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, wrapping_id)
-        self.client.destroy(key_id)
-        self.client.destroy(wrapping_id)
-
     def test_symmetric_key_register_get_destroy(self):
         """
         Test that the ProxyKmipClient can register, retrieve, and destroy a
@@ -125,18 +116,10 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(key)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.SymmetricKey)
-            self.assertEqual(
-                result, key, "expected {0}\nobserved {1}".format(result, key))
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.SymmetricKey)
+        self.assertEqual(
+            result, key, "expected {0}\nobserved {1}".format(result, key))
 
     def test_register_wrapped_get_destroy(self):
         """
@@ -182,8 +165,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             enums.EncodingOption.NO_ENCODING,
             key_wrapping_data.get('encoding_option')
         )
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
-        self.client.destroy(key_id)
     
     def test_register_app_specific_get(self):
         """
@@ -243,9 +224,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             attribute2.attribute_value.application_data
         )
 
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
-        self.client.destroy(key_id)
-
     def test_asymmetric_key_pair_create_get_destroy(self):
         """
         Test that the ProxyKmipClient can create, retrieve, and destroy an
@@ -260,36 +238,19 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIsInstance(public_uid, six.string_types)
         self.assertIsInstance(private_uid, six.string_types)
 
-        try:
-            public_key = self.client.get(public_uid)
-            self.assertIsInstance(public_key, objects.PublicKey)
-            self.assertEqual(
-                public_key.cryptographic_algorithm,
-                enums.CryptographicAlgorithm.RSA)
-            self.assertEqual(public_key.cryptographic_length, 2048)
+        public_key = self.client.get(public_uid)
+        self.assertIsInstance(public_key, objects.PublicKey)
+        self.assertEqual(
+            public_key.cryptographic_algorithm,
+            enums.CryptographicAlgorithm.RSA)
+        self.assertEqual(public_key.cryptographic_length, 2048)
 
-            private_key = self.client.get(private_uid)
-            self.assertIsInstance(private_key, objects.PrivateKey)
-            self.assertEqual(
-                private_key.cryptographic_algorithm,
-                enums.CryptographicAlgorithm.RSA)
-            self.assertEqual(private_key.cryptographic_length, 2048)
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, public_uid)
-            self.client.destroy(public_uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, public_uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy,
-                public_uid)
-
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, private_uid)
-            self.client.destroy(private_uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, private_uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy,
-                private_uid)
+        private_key = self.client.get(private_uid)
+        self.assertIsInstance(private_key, objects.PrivateKey)
+        self.assertEqual(
+            private_key.cryptographic_algorithm,
+            enums.CryptographicAlgorithm.RSA)
+        self.assertEqual(private_key.cryptographic_length, 2048)
 
     def test_public_key_register_get_destroy(self):
         """
@@ -324,18 +285,10 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(key)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.PublicKey)
-            self.assertEqual(
-                result, key, "expected {0}\nobserved {1}".format(result, key))
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.PublicKey)
+        self.assertEqual(
+            result, key, "expected {0}\nobserved {1}".format(result, key))
 
     def test_private_key_register_get_destroy(self):
         """
@@ -432,18 +385,10 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(key)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.PrivateKey)
-            self.assertEqual(
-                result, key, "expected {0}\nobserved {1}".format(result, key))
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.PrivateKey)
+        self.assertEqual(
+            result, key, "expected {0}\nobserved {1}".format(result, key))
 
     def test_x509_certificate_register_get_destroy(self):
         """
@@ -510,19 +455,11 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(cert)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.X509Certificate)
-            self.assertEqual(
-                result, cert, "expected {0}\nobserved {1}".format(
-                    result, cert))
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.X509Certificate)
+        self.assertEqual(
+            result, cert, "expected {0}\nobserved {1}".format(
+                result, cert))
 
     def test_secret_data_register_get_destroy(self):
         """
@@ -538,19 +475,11 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(secret)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.SecretData)
-            self.assertEqual(
-                result, secret, "expected {0}\nobserved {1}".format(
-                    result, secret))
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.SecretData)
+        self.assertEqual(
+            result, secret, "expected {0}\nobserved {1}".format(
+                result, secret))
                 
     def test_secret_data_register_get_destroy_app_specific(self):
         """
@@ -577,55 +506,46 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(secret)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.SecretData)
-            self.assertEqual(
-                result, secret, "expected {0}\nobserved {1}".format(
-                    result, secret))
-            attribute_list = self.client.get_attribute_list(uid)
-            self.assertIn('Application Specific Information', attribute_list)
-            result_id, attribute_list = self.client.get_attributes(
-                uid=uid,
-                attribute_names=['Application Specific Information']
-            )
-            self.assertEqual(uid, result_id)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.SecretData)
+        self.assertEqual(
+            result, secret, "expected {0}\nobserved {1}".format(
+                result, secret))
+        attribute_list = self.client.get_attribute_list(uid)
+        self.assertIn('Application Specific Information', attribute_list)
+        result_id, attribute_list = self.client.get_attributes(
+            uid=uid,
+            attribute_names=['Application Specific Information']
+        )
+        self.assertEqual(uid, result_id)
 
-            attribute = attribute_list[0]
-            self.assertEqual(
-                'Application Specific Information',
-                attribute.attribute_name.value
-            )
-            self.assertEqual(
-                'Testing',
-                attribute.attribute_value.application_namespace
-            )
-            self.assertEqual(
-                'Testing2',
-                attribute.attribute_value.application_data
-            )
+        attribute = attribute_list[0]
+        self.assertEqual(
+            'Application Specific Information',
+            attribute.attribute_name.value
+        )
+        self.assertEqual(
+            'Testing',
+            attribute.attribute_value.application_namespace
+        )
+        self.assertEqual(
+            'Testing2',
+            attribute.attribute_value.application_data
+        )
 
-            attribute2 = attribute_list[1]
-            self.assertEqual(
-                'Application Specific Information',
-                attribute2.attribute_name.value
-            )
-            self.assertEqual(
-                'Testing3',
-                attribute2.attribute_value.application_namespace
-            )
-            self.assertEqual(
-                'Testing4',
-                attribute2.attribute_value.application_data
-            )
-
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        attribute2 = attribute_list[1]
+        self.assertEqual(
+            'Application Specific Information',
+            attribute2.attribute_name.value
+        )
+        self.assertEqual(
+            'Testing3',
+            attribute2.attribute_value.application_namespace
+        )
+        self.assertEqual(
+            'Testing4',
+            attribute2.attribute_value.application_data
+        )
 
     def test_opaque_object_register_get_destroy(self):
         """
@@ -640,17 +560,10 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(obj)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.OpaqueObject)
-            self.assertEqual(
-                result, obj, "expected {0}\nobserved {1}".format(result, obj))
-        finally:
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.OpaqueObject)
+        self.assertEqual(
+            result, obj, "expected {0}\nobserved {1}".format(result, obj))
 
     def test_derive_key_using_pbkdf2(self):
         """
@@ -715,8 +628,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             attribute.attribute_name.value
         )
         self.assertEqual(160, attribute.attribute_value.value)
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
-        self.client.destroy(key_id)
 
     def test_derive_key_using_encryption(self):
         """
@@ -944,10 +855,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
 
         self.assertEqual(plain_text, result)
 
-        # Clean up.
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, key_id)
-        self.client.destroy(key_id)
-
     def test_create_key_pair_sign_signature_verify(self):
         """
         Test that the ProxyKmipClient can create an asymmetric key pair and
@@ -999,18 +906,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         )
 
         self.assertEqual(result, enums.ValidityIndicator.VALID)
-
-        # Clean up.
-        self.client.revoke(
-            enums.RevocationReasonCode.KEY_COMPROMISE,
-            public_key_id
-        )
-        self.client.revoke(
-            enums.RevocationReasonCode.KEY_COMPROMISE,
-            private_key_id
-        )
-        self.client.destroy(public_key_id)
-        self.client.destroy(private_key_id)
 
     def test_certificate_register_locate_destroy(self):
         """
@@ -1436,12 +1331,6 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         )
         self.assertEqual(0, len(result))
 
-        # Clean up the keys
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, a_id)
-        self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, b_id)
-        self.client.destroy(a_id)
-        self.client.destroy(b_id)
-
     def test_split_key_register_get_destroy(self):
         """
         Test that the ProxyKmipClient can register, retrieve, and destroy a
@@ -1468,34 +1357,26 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         uid = self.client.register(key)
         self.assertIsInstance(uid, six.string_types)
 
-        try:
-            result = self.client.get(uid)
-            self.assertIsInstance(result, objects.SplitKey)
-            self.assertEqual(
-                enums.CryptographicAlgorithm.AES,
-                result.cryptographic_algorithm
-            )
-            self.assertEqual(128, result.cryptographic_length)
-            self.assertEqual(
-                (
-                    b'\x00\x01\x02\x03\x04\x05\x06\x07'
-                    b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
-                ),
-                result.value
-            )
-            self.assertEqual(enums.KeyFormatType.RAW, result.key_format_type)
-            self.assertEqual(3, result.split_key_parts)
-            self.assertEqual(1, result.key_part_identifier)
-            self.assertEqual(2, result.split_key_threshold)
-            self.assertEqual(enums.SplitKeyMethod.XOR, result.split_key_method)
-            self.assertIsNone(result.prime_field_size)
-        finally:
-            self.client.revoke(enums.RevocationReasonCode.KEY_COMPROMISE, uid)
-            self.client.destroy(uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.get, uid)
-            self.assertRaises(
-                exceptions.KmipOperationFailure, self.client.destroy, uid)
+        result = self.client.get(uid)
+        self.assertIsInstance(result, objects.SplitKey)
+        self.assertEqual(
+            enums.CryptographicAlgorithm.AES,
+            result.cryptographic_algorithm
+        )
+        self.assertEqual(128, result.cryptographic_length)
+        self.assertEqual(
+            (
+                b'\x00\x01\x02\x03\x04\x05\x06\x07'
+                b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
+            ),
+            result.value
+        )
+        self.assertEqual(enums.KeyFormatType.RAW, result.key_format_type)
+        self.assertEqual(3, result.split_key_parts)
+        self.assertEqual(1, result.key_part_identifier)
+        self.assertEqual(2, result.split_key_threshold)
+        self.assertEqual(enums.SplitKeyMethod.XOR, result.split_key_method)
+        self.assertIsNone(result.prime_field_size)
 
     def test_modify_delete_attribute(self):
         """


### PR DESCRIPTION
Updated tests to use the revoke and destroy in tearDown and not separately in each test. Added an except to handle "An OpaqueData object has no state and cannot be revoked." error to destroy it without revoking it first.