### PR TITLE
Issue 663- Add custom attribute

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -1273,7 +1273,6 @@ class ContactInformation(TextString):
         super(ContactInformation, self).__init__(
             value, Tags.CONTACT_INFORMATION)
 
-
 # 3.39
 # TODO (peter-hamilton) A CustomAttribute TextString is not sufficient to
 # TODO (peter-hamilton) cover all potential custom attributes. This is a
@@ -1282,6 +1281,235 @@ class CustomAttribute(TextString):
 
     def __init__(self, value=None):
         super(CustomAttribute, self).__init__(value, Tags.ATTRIBUTE_VALUE)
+
+
+class VendorAttribute(primitives.Struct):
+
+    def __init__(self, vendor_identification=None, attribute_name=None, attribute_value=None):
+        """
+        Constructs a Custom Vendor Attribute object.
+        Args:
+            vendor_identification (string): The identification string of a vendor. Defaults to None.
+            attribute_name (string): Name of the Vendor Attribute. Defaults to None.
+            attribute_value (string): Value of the Vendor Attribute Defaults to None.
+        """
+        super(VendorAttribute, self).__init__(enums.Tags.VENDOR_ATTRIBUTE)
+        self._vendor_identification = None
+        self._attribute_name = None
+        self._attribute_value = None
+
+        self.vendor_identification = vendor_identification
+        self.attribute_name = attribute_name
+        self.attribute_value = attribute_value
+
+    @property
+    def vendor_identification(self):
+        if self._vendor_identification:
+            return self._vendor_identification.value
+        return None
+
+    @vendor_identification.setter
+    def vendor_identification(self, value):
+        if value is None:
+            self._vendor_identification = None
+        elif isinstance(value, six.string_types):
+            self._vendor_identification = primitives.TextString(
+                value=value,
+                tag=enums.Tags.VENDOR_IDENTIFICATION
+            )
+        else:
+            raise TypeError("The vendor identification must be a string.")
+
+    @property
+    def attribute_name(self):
+        if self._attribute_name:
+            return self._attribute_name.value
+        return None
+
+    @attribute_name.setter
+    def attribute_name(self, value):
+        if value is None:
+            self._attribute_name = None
+        elif isinstance(value, six.string_types):
+            self._attribute_name = primitives.TextString(
+                value=value,
+                tag=enums.Tags.ATTRIBUTE_NAME
+            )
+        else:
+            raise TypeError("The attribute name must be a string.")
+
+    @property
+    def attribute_value(self):
+        if self._attribute_value:
+            return self._attribute_value.value
+        return None
+
+    @attribute_value.setter
+    def attribute_value(self, value):
+        if value is None:
+            self._attribute_value = None
+        elif isinstance(value, six.string_types):
+            self._attribute_value = primitives.TextString(
+                value=value,
+                tag=enums.Tags.ATTRIBUTE_VALUE
+            )
+        else:
+            raise TypeError("The attribute value must be a string.")
+
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_2_0):
+        """
+        Read the data encoding the vendor attribute
+        and decode it.
+
+        Args:
+            input_buffer (stream): A data stream containing encoded object
+                data, supporting a read method; usually a BytearrayStream
+                object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
+        """
+        super(VendorAttribute, self).read(
+            input_buffer,
+            kmip_version=kmip_version
+        )
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
+        if self.is_tag_next(enums.Tags.VENDOR_IDENTIFICATION, local_buffer):
+            self._vendor_identification = primitives.TextString(
+                tag=enums.Tags.VENDOR_IDENTIFICATION
+            )
+            self._vendor_identification.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Vendor Attribute encoding is missing the "
+                "VendorIdentification field."
+            )
+        if self.is_tag_next(enums.Tags.ATTRIBUTE_NAME, local_buffer):
+            self._attribute_name = primitives.TextString(
+                tag=enums.Tags.ATTRIBUTE_NAME
+            )
+            self._attribute_name.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Vendor Attribute encoding is missing the "
+                "AttributeName field."
+            )
+        if self.is_tag_next(enums.Tags.ATTRIBUTE_VALUE, local_buffer):
+            self._attribute_value = primitives.TextString(
+                tag=enums.Tags.ATTRIBUTE_VALUE
+            )
+            self._attribute_value.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Vendor Attribute encoding is missing the "
+                "AttributeValue field."
+            )
+
+        self.is_oversized(local_buffer)
+
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_2_0):
+        """
+        Write the data encoding the Vendor Attribute object to a
+        buffer.
+
+        Args:
+            output_buffer (stream): A data stream in which to encode object
+                data, supporting a write method; usually a BytearrayStream
+                object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
+        """
+        local_buffer = utils.BytearrayStream()
+        if self._vendor_identification:
+            self._vendor_identification.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The Vendor Attribute object is missing the "
+                "VendorIdentification field."
+            )
+
+        if self._attribute_name:
+            self._attribute_name.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The Vendor Attribute object is missing the "
+                "AttributeName field."
+            )
+        if self._attribute_value:
+            self._attribute_value.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The Vendor Attribute object is missing the "
+                "AttributeValue field."
+            )
+
+        self.length = local_buffer.length()
+        super(VendorAttribute, self).write(
+            output_buffer,
+            kmip_version=kmip_version
+        )
+        output_buffer.write(local_buffer.buffer)
+
+    def __repr__(self):
+        args = [
+            "vendor_identification={}".format(
+                repr(self.vendor_identification)
+            ),
+            "attribute_name={}".format(
+                repr(self.attribute_name)
+            ),
+            "attribute_value={}".format(
+                repr(self.attribute_value)
+            )
+        ]
+        return "VendorAttribute({})".format(", ".join(args))
+
+    def __str__(self):
+        value = ", ".join(
+            [
+                "vendor_identification={}".format(self.vendor_identification),
+                "attribute_name={}".format(self.attribute_name),
+                "attribute_value={}".format(self.attribute_value)
+            ]
+        )
+        return "{" + value + "}"
+
+    def __eq__(self, other):
+        if isinstance(other, VendorAttribute):
+            if self.vendor_identification != other.vendor_identification:
+                return False
+            if self.attribute_name != other.attribute_name:
+                return False
+            if self.attribute_value != other.attribute_value:
+                return False
+            return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, VendorAttribute):
+            return not self.__eq__(other)
+        else:
+            return NotImplemented
 
 
 class DerivationParameters(Struct):

--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -126,7 +126,8 @@ class AttributeType(enum.Enum):
     KEY_VALUE_PRESENT                = 'Key Value Present'
     KEY_VALUE_LOCATION               = 'Key Value Location'
     ORIGINAL_CREATION_DATE           = 'Original Creation Date'
-    SENSITIVE                        = "Sensitive"
+    SENSITIVE                        = 'Sensitive'
+    VENDOR_ATTRIBUTE                 = 'Vendor Attribute'
 
 
 class AuthenticationSuite(enum.Enum):
@@ -1588,6 +1589,7 @@ class Tags(enum.Enum):
     COMMON_PROTECTION_STORAGE_MASKS          = 0x420163
     PRIVATE_PROTECTION_STORAGE_MASKS         = 0x420164
     PUBLIC_PROTECTION_STORAGE_MASKS          = 0x420165
+    VENDOR_ATTRIBUTE                         = 0x420166
 
 
 class TicketType(enum.Enum):
@@ -1759,7 +1761,8 @@ attribute_name_tag_table = [
     ("Usage Limits",                      Tags.USAGE_LIMITS),
     ("X.509 Certificate Identifier",      Tags.X_509_CERTIFICATE_IDENTIFIER),
     ("X.509 Certificate Issuer",          Tags.X_509_CERTIFICATE_ISSUER),
-    ("X.509 Certificate Subject",         Tags.X_509_CERTIFICATE_SUBJECT)
+    ("X.509 Certificate Subject",         Tags.X_509_CERTIFICATE_SUBJECT),
+    ("Vendor Attribute",                  Tags.VENDOR_ATTRIBUTE)
 ]
 
 
@@ -2025,7 +2028,8 @@ def is_attribute(tag, kmip_version=None):
         Tags.PROTECTION_STORAGE_MASK,
         Tags.QUANTUM_SAFE,
         Tags.SHORT_UNIQUE_IDENTIFIER,
-        Tags.ATTRIBUTE
+        Tags.ATTRIBUTE,
+        Tags.VENDOR_ATTRIBUTE
     ]
     kmip_2_0_attribute_tags.remove(Tags.CERTIFICATE_IDENTIFIER)
     kmip_2_0_attribute_tags.remove(Tags.CERTIFICATE_SUBJECT)

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -108,6 +108,8 @@ class AttributeValueFactory(object):
             return primitives.Boolean(value, enums.Tags.SENSITIVE)
         elif name is enums.AttributeType.CUSTOM_ATTRIBUTE:
             return attributes.CustomAttribute(value)
+        elif name is enums.AttributeType.VENDOR_ATTRIBUTE:
+            return self._create_vendor_attribute(value)
         else:
             if not isinstance(name, str):
                 raise ValueError('Unrecognized attribute type: '
@@ -200,6 +202,8 @@ class AttributeValueFactory(object):
             return primitives.Boolean(value, enums.Tags.SENSITIVE)
         elif enum is enums.Tags.CUSTOM_ATTRIBUTE:
             return attributes.CustomAttribute(value)
+        elif enum is enums.Tags.VENDOR_ATTRIBUTE:
+            return self._create_vendor_attribute(value)
         else:
             raise ValueError("Unrecognized attribute type: {}".format(enum))
 
@@ -280,6 +284,16 @@ class AttributeValueFactory(object):
             )
         else:
             return attributes.ApplicationSpecificInformation()
+
+    def _create_vendor_attribute(self, info):
+        if info:
+            return attributes.VendorAttribute(
+                vendor_identification=info.get("vendor_identification"),
+                attribute_name=info.get("attribute_name"),
+                attribute_value=info.get("attribute_value")
+            )
+        else:
+            return attributes.VendorAttribute()
 
     def _create_contact_information(self, info):
         if info is None:

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -566,12 +566,20 @@ class ProxyKmipClient(object):
                         index=0
                     )
                     object_attributes.append(attribute)
+        if hasattr(managed_object, '_vendor_attributes'):
+            if managed_object._vendor_attributes:
+                for info in managed_object._vendor_attributes:
+                    attribute = self.attribute_factory.create_attribute(
+                        enums.AttributeType.VENDOR_ATTRIBUTE,
+                        info,
+                        index=0
+                    )
+                    object_attributes.append(attribute)
         template = cobjects.TemplateAttribute(attributes=object_attributes)
         object_type = managed_object.object_type
         # Register the managed object and handle the results
         secret = self.object_factory.convert(managed_object)
         result = self.proxy.register(object_type, template, secret)
-
         status = result.result_status.value
         if status == enums.ResultStatus.SUCCESS:
             return result.uuid

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -740,6 +740,17 @@ class KmipEngine(object):
                     }
                 )
             return values
+        elif attr_name == "Vendor Attribute":
+            values = []
+            for info in managed_object.vendor_attribute:
+                values.append(
+                    {
+                        "vendor_identification": info.vendor_identification,
+                        "attribute_name": info.attribute_name,
+                        "attribute_value": info.attribute_value
+                    }
+                )
+            return values
         elif attr_name == 'Contact Information':
             return None
         elif attr_name == 'Last Change Date':
@@ -782,6 +793,13 @@ class KmipEngine(object):
             for count, v in enumerate(managed_object.app_specific_info):
                 if ((a.application_namespace == v.application_namespace) and
                         (a.application_data == v.application_data)):
+                    return count
+            return None
+        elif attribute_name == "Vendor Attribute":
+            a = attribute_value
+            for count, v in enumerate(managed_object.vendor_attribute):
+                if ((a.vendor_identification == v.vendor_identification) and
+                        (a.attribute_name == v.attribute_name) and (a.attribute_value == v.attribute_value)):
                     return count
             return None
         elif attribute_name == "Certificate Type":
@@ -889,6 +907,15 @@ class KmipEngine(object):
                             application_data=value.application_data
                         )
                     )
+            elif attribute_name == "Vendor Attribute":
+                for value in attribute_value:
+                    managed_object.vendor_attribute.append(
+                        objects.VendorAttribute(
+                            vendor_identification=value.vendor_identification,
+                            attribute_name=value.attribute_name,
+                            attribute_value=value.attribute_value
+                        )
+                    )
             elif attribute_name == "Object Group":
                 for value in attribute_value:
                     # TODO (peterhamilton) Enforce uniqueness of object groups
@@ -962,6 +989,11 @@ class KmipEngine(object):
             a = managed_object.app_specific_info[attribute_index]
             a.application_namespace = attribute_value.application_namespace
             a.application_data = attribute_value.application_data
+        elif attribute_name == "Vendor Attribute":
+            a = managed_object.vendor_attribute[attribute_index]
+            a.vendor_identification = attribute_value.vendor_identification
+            a.attribute_name = attribute_value.attribute_name
+            a.attribute_value = attribute_value.attribute_value
         elif attribute_name == "Name":
             name_value = attribute_value.name_value
             managed_object.names[attribute_index] = name_value.value
@@ -1005,6 +1037,14 @@ class KmipEngine(object):
                     attribute_value = objects.ApplicationSpecificInformation(
                         application_namespace=namespace,
                         application_data=attribute_value.application_data
+                    )
+            elif attribute_name == "Vendor Attribute":
+                attribute_list = managed_object.vendor_attribute
+                if attribute_value is not None:
+                    attribute_value = objects.VendorAttribute(
+                        vendor_identification=attribute_value.vendor_identification,
+                        attribute_name=attribute_value.attribute_name,
+                        attribute_value=attribute_value.attribute_value
                     )
             elif attribute_name == "Object Group":
                 attribute_list = managed_object.object_groups
@@ -2264,6 +2304,27 @@ class KmipEngine(object):
                                 "specific information attributes.".format(
                                     v.get("application_namespace"),
                                     v.get("application_data")
+                                )
+                            )
+                            add_object = False
+                            break
+                    elif name == "Vendor Attribute":
+                        vendor_identification = value.vendor_identification
+                        attribute_name = value.attribute_name
+                        attribute_value = value.attribute_value
+                        v = {
+                            "vendor_identification": vendor_identification,
+                            "attribute_name": attribute_name,
+                            "attribute_value": attribute_value
+                        }
+                        if v not in attribute:
+                            self._logger.debug(
+                                "Failed match: "
+                                "the specified vendor attributes ('{}', '{}', '{) does not match any "
+                                "of the object's associated vendor attributes.".format(
+                                    v.get("vendor_identification"),
+                                    v.get("attribute_name"),
+                                    v.get("attribute_value")
                                 )
                             )
                             add_object = False

--- a/kmip/services/server/policy.py
+++ b/kmip/services/server/policy.py
@@ -979,6 +979,30 @@ class AttributePolicy(object):
                 ),
                 contents.ProtocolVersion(1, 0)
             ),
+            'Vendor Attribute': AttributeRuleSet(
+                False,
+                ('server', 'client'),  # Only if omitted in client request
+                True,  # Only if attribute omitted in client request
+                True,
+                True,
+                True,
+                (
+                    enums.Operation.RECERTIFY,
+                    enums.Operation.REKEY,
+                    enums.Operation.REKEY_KEY_PAIR
+                ),
+                (
+                    enums.ObjectType.CERTIFICATE,
+                    enums.ObjectType.SYMMETRIC_KEY,
+                    enums.ObjectType.PUBLIC_KEY,
+                    enums.ObjectType.PRIVATE_KEY,
+                    enums.ObjectType.SPLIT_KEY,
+                    enums.ObjectType.TEMPLATE,
+                    enums.ObjectType.SECRET_DATA,
+                    enums.ObjectType.OPAQUE_DATA
+                ),
+                contents.ProtocolVersion(1, 0)
+            ),
             'Contact Information': AttributeRuleSet(
                 False,
                 ('server', 'client'),

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -498,13 +498,13 @@ class TestAttributeValueFactory(testtools.TestCase):
         self.assertEqual(0, date.value)
         self.assertEqual(enums.Tags.LAST_CHANGE_DATE, date.tag)
 
-    def test_create_custom_attribute(self):
+    def test_create_vendor_attribute(self):
         """
-        Test that a CustomAttribute can be created.
+        Test that a VendorAttribute can be created.
         """
         custom = self.factory.create_attribute_value(
-            enums.AttributeType.CUSTOM_ATTRIBUTE, None)
-        self.assertIsInstance(custom, attributes.CustomAttribute)
+            enums.AttributeType.VENDOR_ATTRIBUTE, None)
+        self.assertIsInstance(custom, attributes.VendorAttribute)
 
     def test_create_sensitive(self):
         """

--- a/kmip/tests/unit/core/test_enums.py
+++ b/kmip/tests/unit/core/test_enums.py
@@ -450,37 +450,37 @@ class TestEnumUtilityFunctions(testtools.TestCase):
 
     def test_is_attribute_removed_in_kmip_2_0(self):
         result = enums.is_attribute(
-            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.Tags.VENDOR_ATTRIBUTE,
             enums.KMIPVersion.KMIP_1_0
         )
         self.assertTrue(result)
 
         result = enums.is_attribute(
-            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.Tags.VENDOR_ATTRIBUTE,
             enums.KMIPVersion.KMIP_1_1
         )
         self.assertTrue(result)
 
         result = enums.is_attribute(
-            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.Tags.VENDOR_ATTRIBUTE,
             enums.KMIPVersion.KMIP_1_2
         )
         self.assertTrue(result)
 
         result = enums.is_attribute(
-            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.Tags.VENDOR_ATTRIBUTE,
             enums.KMIPVersion.KMIP_1_3
         )
         self.assertTrue(result)
 
         result = enums.is_attribute(
-            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.Tags.VENDOR_ATTRIBUTE,
             enums.KMIPVersion.KMIP_1_4
         )
         self.assertTrue(result)
 
         result = enums.is_attribute(
-            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.Tags.VENDOR_ATTRIBUTE,
             enums.KMIPVersion.KMIP_2_0
         )
         self.assertFalse(result)


### PR DESCRIPTION
Still a WIP. Getting a vendor attribute has no value type error.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/PyKMIP-0.11.0.dev1-py3.8.egg/kmip/services/server/session.py", line 167, in _handle_message_loop
    request.read(request_data, kmip_version=kmip_version)
  File "/usr/local/lib/python3.8/dist-packages/PyKMIP-0.11.0.dev1-py3.8.egg/kmip/core/messages/messages.py", line 485, in read
    batch_item.read(istream, kmip_version=kmip_version)
  File "/usr/local/lib/python3.8/dist-packages/PyKMIP-0.11.0.dev1-py3.8.egg/kmip/core/messages/messages.py", line 309, in read
    self.request_payload.read(tstream, kmip_version=kmip_version)
  File "/usr/local/lib/python3.8/dist-packages/PyKMIP-0.11.0.dev1-py3.8.egg/kmip/core/messages/payloads/register.py", line 210, in read
    self._template_attribute.read(
  File "/usr/local/lib/python3.8/dist-packages/PyKMIP-0.11.0.dev1-py3.8.egg/kmip/core/objects.py", line 3478, in read
    attribute.read(tstream, kmip_version=kmip_version)
  File "/usr/local/lib/python3.8/dist-packages/PyKMIP-0.11.0.dev1-py3.8.egg/kmip/core/objects.py", line 117, in read
    raise Exception("No value type for {}".format(enum_name))
Exception: No value type for VENDOR_ATTRIBUTE
```